### PR TITLE
Dependency update to nexus 3.70.0-03 including fix for broken API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.sonatype.nexus.plugins</groupId>
 		<artifactId>nexus-plugins</artifactId>
-		<version>3.49.0-02</version>
+		<version>3.70.0-03</version>
 	</parent>
 
 	<groupId>com.pingunaut.nexus</groupId>
@@ -17,12 +17,12 @@
 	<packaging>bundle</packaging>
 
 	<properties>
-		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
-		<maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
-		<maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-		<karaf-maven-plugin.version>4.4.3</karaf-maven-plugin.version>
-		<maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
+		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+		<jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+		<maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+		<maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
+		<karaf-maven-plugin.version>4.4.6</karaf-maven-plugin.version>
+		<maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -111,17 +111,17 @@
 					<dependency>
 						<groupId>javax.xml.bind</groupId>
 						<artifactId>jaxb-api</artifactId>
-						<version>2.2.11</version>
+						<version>2.3.1</version>
 					</dependency>
 					<dependency>
 						<groupId>com.sun.xml.bind</groupId>
 						<artifactId>jaxb-core</artifactId>
-						<version>2.2.11</version>
+						<version>4.0.5</version>
 					</dependency>
 					<dependency>
 						<groupId>com.sun.xml.bind</groupId>
 						<artifactId>jaxb-impl</artifactId>
-						<version>2.2.11</version>
+						<version>4.0.5</version>
 					</dependency>
 					<dependency>
 						<groupId>javax.activation</groupId>

--- a/src/main/java/com/pingunaut/nexus3/crowd/plugin/internal/CrowdUserManager.java
+++ b/src/main/java/com/pingunaut/nexus3/crowd/plugin/internal/CrowdUserManager.java
@@ -108,4 +108,9 @@ public class CrowdUserManager extends AbstractReadOnlyUserManager {
 		}
 		return completeUserRolesAndSource(u, roleIds);
 	}
+
+	@Override
+	public boolean isConfigured() {
+		return false;
+	}
 }


### PR DESCRIPTION
With Nexus 3.70.0-03 the plugin was broken due to an added interface method ```UserManager#isConfigured()```.
